### PR TITLE
Update README links and simplify CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,8 +2,6 @@ name: test-run
 
 on:
   workflow_dispatch:
-  schedule:
-  - cron: '30 21 * * *'
 
 jobs:
   build:

--- a/README.md
+++ b/README.md
@@ -2,11 +2,11 @@
 
 <p align="center">
   <a href="https://github.com/Claudiu-Munteanu/automationexercise-api-tests-restassured-testng-java/actions/workflows/ci.yml">
-    <img src="https://github.com/Claudiu-Munteanu/automationexercise-api-tests-restassured-testng-java/actions/workflows/ci.yml/badge.svg" alt="CI" width="250"/>
+    <img src="https://github.com/Claudiu-Munteanu/automationexercise-api-tests-restassured/actions/workflows/ci.yml/badge.svg" alt="CI" width="250"/>
   </a>
 </p>
 <p align="center">
-  <a href="https://claudiu-munteanu.github.io/automationexercise-api-tests-restassured-testng-java/">
+  <a href="https://claudiu-munteanu.github.io/automationexercise-api-tests-restassured/">
     <img src="https://img.shields.io/badge/Allure_Report:-Click Here-4e7eff?logo=allure&logoColor=white" alt="Allure Report" width="300"/>
   </a>
 </p>


### PR DESCRIPTION
Updated README with corrected GitHub links for CI badge and Allure Report. Removed scheduled trigger from the CI workflow for simplification.